### PR TITLE
Tune up output

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,25 +17,5 @@ This mostly consist of tool chains for
  - building the docs (still forthcoming)
  - gather and run the tests
 
-The aim of these tools is that, if you run them on a code base, you should end up with something which conforms to 
-mewbot's guidelines.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+The aim of these tools is that, if you run them on a code base, you should
+end up with something which conforms to mewbot's guidelines.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,16 +19,16 @@ unsafe-load-any-extension = "no"
 
 jobs=1
 
+[tool.pylint."MESSAGES CONTROL"]
+
+disable=[]
+
 [tool.pydocstyle]
 
 convention="pep257"
 add-ignore=["D200", "D202", "D401"]
 add-select=["D204", "D213", "D416", "D417"]
 ignore-self-only-init=true
-
-[tool.pylint."MESSAGES CONTROL"]
-
-disable=[]
 
 [tool.coverage.run]
 
@@ -50,5 +50,5 @@ profile = "black"
 py_version=310
 sections = ['FUTURE', 'TYPING', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER']
 known_typing = ["typing", "types", "collections.abc"]
-# 9 is black compatible, bu does not look great
+# 9 is black compatible, but does not look great
 multi_line_output = 3

--- a/src/mewbot_dev_tools/lint.py
+++ b/src/mewbot_dev_tools/lint.py
@@ -69,9 +69,11 @@ class LintToolchain(BanditMixin):
     def run(self) -> Iterable[Annotation]:
         """Runs the linting tools in sequence."""
 
-        yield from self.lint_ruff()
+        # Linters that can mutate code
         yield from self.lint_isort()
         yield from self.lint_black()
+        yield from self.lint_ruff()
+        # Linters that only read code
         yield from self.lint_flake8()
         yield from self.lint_mypy()
         yield from self.lint_pylint()
@@ -226,7 +228,12 @@ class LintToolchain(BanditMixin):
         Time is also less of a factor in a rare CI acceptance run.
         """
 
-        result = self.run_tool("Ruff", "ruff")
+        args = ["ruff"]
+
+        if not self.in_ci:
+            args.extend("--fix")
+
+        result = self.run_tool("Ruff", *args)
 
         result_lines = result.stdout.decode("utf-8", errors="replace")
 

--- a/src/mewbot_dev_tools/security_analysis.py
+++ b/src/mewbot_dev_tools/security_analysis.py
@@ -46,14 +46,10 @@ class BanditMixin(ToolChain):
         bandit scans a code base for security vulnerabilities.
         """
 
-        args = ["bandit", "-r"]
+        args = ["bandit", "-c", "pyproject.toml", "-r"]
 
-        if self.in_ci:
-            # Number of "l"s in -ll e.t.c controls the warning level
-            # default to medium and higher severity
-            args.extend(["--quiet", "-ll"])
-        else:
-            args.extend(["-ll"])
+        if not self.in_ci:
+            args.extend(["--quiet"])
 
         result = self.run_tool("Bandit (Security Analysis)", *args)
 

--- a/src/mewbot_dev_tools/terminal.py
+++ b/src/mewbot_dev_tools/terminal.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from types import TracebackType
 from typing import IO
 
+import pprint
 import shutil
 import sys
 
@@ -34,6 +35,7 @@ class CommandDelimiter:
         """
         self.tool_name = tool_name
         self.in_ci = in_ci
+        self.args = args
         self.delim_char = delim_char
 
     @property
@@ -51,6 +53,7 @@ class CommandDelimiter:
 
         if self.in_ci:
             sys.stdout.write(f"::group::{self.tool_name}\n")
+            sys.stdout.write(f"Running {name} with args = \n{pprint.pformat(arg_list)}\n")
         else:
             trailing_dash_count = min(80, self.terminal_width) - 6 - len(self.tool_name)
             sys.stdout.write(

--- a/src/mewbot_dev_tools/toolchain.py
+++ b/src/mewbot_dev_tools/toolchain.py
@@ -15,7 +15,6 @@ import asyncio
 import dataclasses
 import json
 import os
-import pprint
 import subprocess
 import sys
 from io import BytesIO
@@ -180,11 +179,9 @@ class ToolChain(abc.ABC):
         """
 
         # Print output header
-        with CommandDelimiter(name, self.in_ci):
+        with CommandDelimiter(name, self.in_ci, arg_list):
             env = env.copy()
             env.update(os.environ)
-
-            print(f"Running {name} with args = \n{pprint.pformat(arg_list)}\n")
 
             process = await asyncio.create_subprocess_exec(
                 *arg_list,


### PR DESCRIPTION
The primary purpose of this change is to make it easier to identify the next action required whilst using this toolchain on the command line.

- Run black before ruff so it sees fewer formatting errors
- Run ruff in --fix mode, so it fixes the stuff it can
- Run bandit in quiet mode, with no defined level, but reading config from pyproject.toml
- Only output the args list in CI, to reduce clutter on the terminal